### PR TITLE
Added support for different credential providers

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -184,11 +184,12 @@ func createConfigFile() {
 # Connection settings for deployment target (FTP only)
 ftp:
   host: <enter host id / ip address>
-  port: <enter port - usually 21 for FTP over TLS>
+  port: <enter port - usually 21 for FTP over TLS>  
+  rootdir: <enter root directory of website, e.g. /public_html/>
+  disabletls: false  
+  credentialProvider: classic
   user: <enter user id>
   pwd: <enter password>
-  rootdir: <enter root directory of website, e.g. /public_html/>
-	disabletls: false
 
 # Connection settings for deployment target (SFTP only)
 sftp:

--- a/cred/classic.go
+++ b/cred/classic.go
@@ -1,0 +1,35 @@
+package cred
+
+import (	
+	"errors"
+	"github.com/spf13/viper"
+)
+
+/**
+	CredentialProvider which reads the credentials directly from the config file
+	(old behavior)
+**/
+type ClassicCredProvider struct {			
+}
+
+func (cstore ClassicCredProvider) GetCredentials(connectionType string) (credentials *Credentials, err error) {	
+
+	uid := viper.GetString(connectionType + ".user")
+	pwd := viper.GetString(connectionType + ".pwd")
+
+	serr := ""
+	
+	if uid == "" {
+		serr = serr + "UID not found. Define " + connectionType + ".user in config file. "
+	}
+	if uid == "" {
+		serr = serr + "PWD not found. Define " + connectionType + ".pwd in config file. "
+	}
+	
+	if (serr != "") {
+		return nil, errors.New(serr)
+	}
+
+	return &Credentials{ UID: uid, PWD: pwd}, nil
+}
+

--- a/cred/cred.go
+++ b/cred/cred.go
@@ -1,0 +1,26 @@
+package cred
+
+type Credentials struct {
+	UID string
+	PWD string	
+}
+
+type CredentialProvider interface {	
+	// connectionType e.g. ftp, sftp
+	GetCredentials(connectionType string) (*Credentials, error)
+}
+
+func GetCredentialProvider(identifier string) CredentialProvider {
+	switch identifier {
+		case "classic":
+			return ClassicCredProvider{}
+		case "interactive":
+			return InteractiveCredProvider{}		
+		case "pwdfile":
+			return PwdFileCredProvider{}
+		case "wincred":
+			return WinCredProvider{}
+		default:
+			return nil;
+	}
+}

--- a/cred/interactive.go
+++ b/cred/interactive.go
@@ -1,0 +1,68 @@
+package cred
+
+import (		
+	"fmt"
+	"os"
+	"bufio"
+	"github.com/eiannone/keyboard"
+	"github.com/spf13/viper"
+)
+
+/**
+	CredentialProvider which asks the user to input their credentials on stdin
+	once they are required
+**/
+type InteractiveCredProvider struct {			
+}
+
+func readPwd() (pwd string, err error) {
+	s := ""
+
+	for {
+		char, key, err := keyboard.GetSingleKey()
+	
+		if (err != nil) {
+			return "", err
+		}
+	
+		if (key == keyboard.KeyEnter) {
+			break
+		}
+		
+		s += string(char)
+	}
+	
+	return s, err
+}
+
+func (cstore InteractiveCredProvider) GetCredentials(connectionType string) (credentials *Credentials, err error) {	
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Println("Please enter credentials for connection type " + connectionType);
+	
+	// is the username preset?
+	uname := viper.GetString(connectionType + ".user")	
+	
+	if (uname != "") {
+		fmt.Println("Username: " + uname);
+	} else {
+		// user has to enter username
+		fmt.Print("Enter username: ");				
+		unameBy, _, err := reader.ReadLine()
+		uname = string(unameBy)
+
+		if (err != nil) {
+			return nil, err
+		}
+	}
+	
+	fmt.Print("Enter password (input will be hidden): ");
+	pwd, err := readPwd();	
+	
+	if (err != nil) {
+		return nil, err
+	}
+		      
+	return &Credentials{ UID: uname, PWD: pwd }, nil		    	
+}
+

--- a/cred/pwdfile.go
+++ b/cred/pwdfile.go
@@ -1,0 +1,44 @@
+package cred
+
+import (	
+	"errors"
+	"github.com/spf13/viper"
+)
+
+/**
+	CredentialProvider which reads the credentials from a separate file
+**/
+type PwdFileCredProvider struct {			
+}
+
+func (cstore PwdFileCredProvider) GetCredentials(connectionType string) (credentials *Credentials, err error) {	
+
+	pwdfile := viper.GetString(connectionType + ".pwdfile")
+	
+	pwdConfig := viper.New()
+    pwdConfig.SetConfigName(pwdfile)
+    pwdConfig.AddConfigPath(".")
+    err = pwdConfig.ReadInConfig()
+	if err != nil {
+        return nil, err
+    }
+	
+	uid := pwdConfig.GetString(connectionType + ".user")
+	pwd := pwdConfig.GetString(connectionType + ".pwd")
+
+	serr := ""
+	
+	if uid == "" {
+		serr = serr + "UID not found. Define " + connectionType + ".user in credential config file. "
+	}
+	if uid == "" {
+		serr = serr + "PWD not found. Define " + connectionType + ".pwd in credential config file. "
+	}
+	
+	if (serr != "") {
+		return nil, errors.New(serr)
+	}
+
+	return &Credentials{ UID: uid, PWD: pwd}, nil
+}
+

--- a/cred/wincred_other.go
+++ b/cred/wincred_other.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package cred
+
+import "errors"
+
+/**
+	Credential Provider which retrieves the credentials from the Windows Credential Manager
+	(Windows only, naturally)
+**/
+type WinCredProvider struct {			
+}
+
+func (cstore WinCredProvider) GetCredentials(connectionType string) (credentials *Credentials, err error) {		
+	return nil, errors.New("The wincred credential provider is only supported on Windows");	
+}

--- a/cred/wincred_windows.go
+++ b/cred/wincred_windows.go
@@ -1,0 +1,35 @@
+package cred
+
+import (	
+	"errors"	
+	"strings"
+	"github.com/danieljoos/wincred"
+	"github.com/spf13/viper"
+)
+
+/**
+	Credential Provider which retrieves the credentials from the Windows Credential Manager
+	(Windows only, naturally)
+**/
+type WinCredProvider struct {			
+}
+
+func (cstore WinCredProvider) GetCredentials(connectionType string) (credentials *Credentials, err error) {	
+	identifier := viper.GetString(connectionType + ".wincred-identifier")
+	
+	if (identifier == "") {
+		return nil, errors.New("Wincred identifier not found. Define " + connectionType +".wincred-identifier in config file.")
+	}
+
+	cred, err := wincred.GetGenericCredential(identifier)		
+    if err != nil {        
+		return nil, err			
+    }
+	
+	// the returned password contains null bytes between
+	// the characters for some reason -> remove these
+	pwd := string(cred.CredentialBlob)
+	pwd = strings.Replace(pwd, string(0), "", -1)
+	
+	return &Credentials{ UID: cred.UserName, PWD: pwd }, nil			
+}


### PR DESCRIPTION
Thanks for this useful tool. I am now using it to deploy my hugo sites automatically :)

As I did not want to store my username and password in the config file I added support for "credential providers" which allow to retrieve credentials from different sources.
For this I added a new property to the config file _credentialProvider_ to allow the user to select a credential provider.
Right now, available providers are:
* classic: same behavior as before, user and pwd go directly in the config file (when the credentialProvider property is not given, this one is used)
* interactive: The user is asked to type username and password into the console window (username can be preset using the "old" _user_ value in the config file)
* pwdfile: The user can declare the property _pwdfile_ in the config and the _user_ and _pwd_ values will be read from there (same folder where the config file is located)
* wincred: Credentials are retrieved from the Windows Credential Manager by using the identifier given in the config file (_wincred-identifier_). Naturally, this only works on Windows

Maybe you find this useful enough to merge it. Right now I only tested it on Windows.